### PR TITLE
Add multiple code languages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       BENCH_MODE: ${BENCH_MODE}
       BENCH_FOLDS_OVERRIDE: ${BENCH_FOLDS_OVERRIDE}
       EXTENDED_SCHEMA: ${EXTENDED_SCHEMA}
+      CODE_LANG: ${CODE_LANG}
 networks:
   python_no_inet:
     driver: bridge

--- a/environments/runtime/Dockerfile
+++ b/environments/runtime/Dockerfile
@@ -41,6 +41,70 @@ RUN apt-get install -y --no-install-recommends \
 # No cuda support
 
 # -------------------------------------------------------------------
+# install Julia
+# -------------------------------------------------------------------
+
+# https://github.com/docker-library/julia/blob/master/stable/bookworm/Dockerfile
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+ENV JULIA_VERSION 1.12.6
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.12.6.sha256
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') \
+			url='https://julialang-s3.julialang.org/bin/linux/x64/1.12/julia-1.12.6-linux-x86_64.tar.gz'; \
+			sha256='bbabf3bef19421a9dbd24a767d807606ab85e444323b5a1c73ffe293fa3d079a'; \
+			;; \
+		'i386') \
+			url='https://julialang-s3.julialang.org/bin/linux/x86/1.12/julia-1.12.6-linux-i686.tar.gz'; \
+			sha256='2ab43d56adfe96c7b0b9ddab0e049f54f49df24049ec8b482c26737c42af28cd'; \
+			;; \
+		'arm64') \
+			url='https://julialang-s3.julialang.org/bin/linux/aarch64/1.12/julia-1.12.6-linux-aarch64.tar.gz'; \
+			sha256='029b93b857bd0ffd627f9a8580d3bbaa63daf008d7b7aed02fbceb8fd57c4899'; \
+			;; \
+		*) \
+			echo >&2 "error: current architecture ($arch) does not have a corresponding Julia binary release"; \
+			exit 1; \
+			;; \
+	esac; \
+	\
+	curl -fL -o julia.tar.gz.asc "$url.asc"; \
+	curl -fL -o julia.tar.gz "$url"; \
+	\
+	echo "$sha256 *julia.tar.gz" | sha256sum --strict --check -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+# Disable autoremove for now
+#   apt-mark auto '.*' > /dev/null; \
+#   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+#   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+# -------------------------------------------------------------------
 # uv (correct path: /root/.local/bin)
 # -------------------------------------------------------------------
 ARG PYTHON_VERSION=3.12

--- a/environments/runtime/Dockerfile
+++ b/environments/runtime/Dockerfile
@@ -19,7 +19,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # -------------------------------------------------------------------
-# uv (правильный путь: /root/.local/bin)
+# install R
+# -------------------------------------------------------------------
+
+# Base instructions taken from https://cran.r-project.org/bin/linux/debian/
+# Packages taken from https://github.com/rocker-org/rocker/blob/master/r-base/4.6.0/Dockerfile
+# This installs a whatever version of R
+RUN apt-get install -y --no-install-recommends \
+    libopenblas0-pthread \
+    littler \
+    r-cran-littler \
+    r-base \
+    r-base-dev \
+    r-base-core \
+    r-recommended \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
+    && rm -rf /var/lib/apt/lists/*
+
+# We assume that the base library is writable, and the agent is executed from root
+# R-devel is not installed here
+# No cuda support
+
+# -------------------------------------------------------------------
+# uv (correct path: /root/.local/bin)
 # -------------------------------------------------------------------
 ARG PYTHON_VERSION=3.12
 ARG REQUIREMENTS=/tmp/requirements.txt
@@ -36,7 +58,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
  && mv /root/.local/bin/uvx /usr/local/bin/uvx
 
 # -------------------------------------------------------------------
-# pip wrapper для uv
+# pip wrapper for uv
 # -------------------------------------------------------------------
 RUN printf '#!/bin/bash\nexec uv pip "$@"\n' > /usr/local/bin/pip \
  && chmod +x /usr/local/bin/pip \

--- a/environments/runtime/requirements.txt
+++ b/environments/runtime/requirements.txt
@@ -73,3 +73,4 @@ fastapi==0.116.1
 chardet
 rpy2==3.6.7
 juliacall==0.9.35
+packaging==26.2

--- a/environments/runtime/requirements.txt
+++ b/environments/runtime/requirements.txt
@@ -71,3 +71,5 @@ tqdm==4.67.1
 xlrd==2.0.2
 fastapi==0.116.1
 chardet
+rpy2==3.6.7
+juliacall==0.9.35

--- a/grade.sh
+++ b/grade.sh
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "Usage: $0 [-r|--rebuild] submission_script competition_id lang bench_mode extended_schema [folds]"
+    echo "Usage: $0 [-r|--rebuild] submission_script competition_id lang bench_mode extended_schema code_lang [folds]"
     echo ""
     echo "  -r, --rebuild      Rebuild the container before running"
     echo ""
@@ -12,6 +12,7 @@ usage() {
     echo "  lang               Competition language"
     echo "  bench_mode         Benchmarking mode (MONO_PREDICT or MODULAR_PREDICT)"
     echo "  extended_schema    Use extended schema for submission code"
+    echo "  code_lang          Submission code language (\"python\", \"r\" or \"julia\")"
     echo ""
     echo "Optional:"
     echo "  folds              Override the number of folds to run"
@@ -35,18 +36,19 @@ COMPETITION_ID="${POSITIONAL[1]}"
 BENCH_LANG="${POSITIONAL[2]}"
 BENCH_MODE="${POSITIONAL[3]}"
 EXTENDED_SCHEMA="${POSITIONAL[4]}"
+CODE_LANG="${POSITIONAL[5]}"
 
-if [[ ${#POSITIONAL[@]} -gt 5 ]]; then
-	BENCH_FOLDS_OVERRIDE="${POSITIONAL[5]}"
+if [[ ${#POSITIONAL[@]} -gt 6 ]]; then
+	BENCH_FOLDS_OVERRIDE="${POSITIONAL[6]}"
 fi
 
 # Check for required arguments
-if [[ -z $SUBMISSION_SCRIPT || -z $COMPETITION_ID || -z $BENCH_LANG || -z $BENCH_MODE || -z $EXTENDED_SCHEMA ]]; then
+if [[ -z $SUBMISSION_SCRIPT || -z $COMPETITION_ID || -z $BENCH_LANG || -z $BENCH_MODE || -z $EXTENDED_SCHEMA || -z $CODE_LANG ]]; then
     usage
 fi
 
 # Calculate the submission name
-SUBMISSION_NAME="submission_${COMPETITION_ID}-${BENCH_LANG}-python-only_code"
+SUBMISSION_NAME="submission_${COMPETITION_ID}-${BENCH_LANG}-${CODE_LANG}-only_code"
 
 # Prepare the folders
 if [[ ! -d "./python/submission" ]]; then
@@ -55,8 +57,9 @@ fi
 
 
 
-
-echo "" > "./python/submission/$SUBMISSION_NAME/__init__.py"
+if [[ "$CODE_LANG" == "python" ]]; then
+   echo "" > "./python/submission/$SUBMISSION_NAME/__init__.py"
+fi
 
 echo "ALL OK"
 # Copy the submission script
@@ -69,6 +72,7 @@ export BENCH_LANG="$BENCH_LANG"
 export BENCH_MODE="$BENCH_MODE"
 export BENCH_FOLDS_OVERRIDE="$BENCH_FOLDS_OVERRIDE"
 export EXTENDED_SCHEMA="$EXTENDED_SCHEMA"
+export CODE_LANG="$CODE_LANG"
 
 # Rebuild container if requested
 if [[ "$REBUILD" == "true" ]]; then

--- a/grade.sh
+++ b/grade.sh
@@ -12,7 +12,7 @@ usage() {
     echo "  lang               Competition language"
     echo "  bench_mode         Benchmarking mode (MONO_PREDICT or MODULAR_PREDICT)"
     echo "  extended_schema    Use extended schema for submission code"
-    echo "  code_lang          Submission code language (\"python\", \"r\" or \"julia\")"
+    echo "  code_lang          Submission code language (\"python\", \"rlang\" or \"julia\")"
     echo ""
     echo "Optional:"
     echo "  folds              Override the number of folds to run"
@@ -60,10 +60,25 @@ fi
 if [[ "$CODE_LANG" == "python" ]]; then
    echo "" > "./python/submission/$SUBMISSION_NAME/__init__.py"
 fi
+if [[ "$CODE_LANG" == "julia" ]]; then
+   cat > "./python/submission/$SUBMISSION_NAME/Project.toml" << EOF   # TODO check that this Project.toml is ok
+name = "submission"
+uuid = "202b1717-a144-4415-8d3a-a1bfc0cbf60e"
+version = "0.0.1"
+EOF
+fi
 
 echo "ALL OK"
 # Copy the submission script
+if [[ "$CODE_LANG" == "python" ]]; then
 cp "$SUBMISSION_SCRIPT" "./python/submission/$SUBMISSION_NAME/code.py"
+fi
+if [[ "$CODE_LANG" == "rlang" ]]; then
+cp "$SUBMISSION_SCRIPT" "./python/submission/$SUBMISSION_NAME/code.r"
+fi
+if [[ "$CODE_LANG" == "python" ]]; then
+cp "$SUBMISSION_SCRIPT" "./python/submission/$SUBMISSION_NAME/code.jl"
+fi
 echo "ALL OK"
 # Competition init
 export COMPETITION_ID="$COMPETITION_ID"

--- a/grade_manual.py
+++ b/grade_manual.py
@@ -14,6 +14,7 @@ def main():
     parser.add_argument('--mode', '-m', choices=['mono', 'modular'], default='modular',
                        help='Execution mode: mono (monolithic) or modular (default: modular)')
     parser.add_argument('--extended_schema', '-e', choices=['y', 'n'], default='y', help='Use extended schema for submission code')
+    parser.add_argument('--code_lang', '-c', choices=['python', 'r', 'julia'], default='python', help='Code language')
     parser.add_argument('--folds', '-f', type=int, help='Override number of folds')
     parser.add_argument('--rebuild', '-r', action='store_true', 
                        help='Rebuild Docker container before running')
@@ -38,21 +39,22 @@ def main():
         sys.exit(1)
     
     pipeline.prepare_train_data(target_comp, args.seed)
-    print("✓ Data preparation complete on host.")
+    print("[OK] Data preparation complete on host.")
 
-    # 1.5 Ensure submission package __init__.py exists for Docker grading
     submission_dir = os.path.join(
-        'python', 'submission', f"submission_{args.competition_id}-{args.lang}-python-only_code"
+        'python', 'submission', f"submission_{args.competition_id}-{args.lang}-{args.code_lang}-only_code"
     )
     os.makedirs(submission_dir, exist_ok=True)
-    init_file = os.path.join(submission_dir, '__init__.py')
-    try:
-        if not os.path.exists(init_file):
-            with open(init_file, 'w', encoding='utf-8') as f:
-                f.write('')
-        print(f"✓ Ensured package file at {init_file}")
-    except Exception as e:
-        print(f"Warning: Could not create __init__.py at {init_file}: {e}")
+    # 1.5 Ensure submission package __init__.py exists for Docker grading
+    if args.code_lang == "python":
+        init_file = os.path.join(submission_dir, '__init__.py')
+        try:
+            if not os.path.exists(init_file):
+                with open(init_file, 'w', encoding='utf-8') as f:
+                    f.write('')
+            print(f"[OK] Ensured package file at {init_file}")
+        except Exception as e:
+            print(f"Warning: Could not create __init__.py at {init_file}: {e}")
 
     # 2. Call the existing grade.sh script to handle Docker
     print("[2/3] Invoking grade.sh to run inside Docker container...")
@@ -63,7 +65,8 @@ def main():
             args.competition_id,
             args.lang,
             'MONO_PREDICT' if args.mode == 'mono' else 'MODULAR_PREDICT',
-            args.extended_schema
+            args.extended_schema,
+            args.code_lang
         ]
         
         if args.rebuild:
@@ -86,7 +89,7 @@ def main():
     # 3. CLEANUP
     print("[3/3] Cleaning up prepared data on host...")
     pipeline.erase_train_data(target_comp)
-    print("✓ Cleanup complete.")
+    print("[OK] Cleanup complete.")
     print("=== Manual test finished ===")
 
 if __name__ == "__main__":

--- a/grade_manual.py
+++ b/grade_manual.py
@@ -14,7 +14,7 @@ def main():
     parser.add_argument('--mode', '-m', choices=['mono', 'modular'], default='modular',
                        help='Execution mode: mono (monolithic) or modular (default: modular)')
     parser.add_argument('--extended_schema', '-e', choices=['y', 'n'], default='y', help='Use extended schema for submission code')
-    parser.add_argument('--code_lang', '-c', choices=['python', 'r', 'julia'], default='python', help='Code language')
+    parser.add_argument('--code_lang', '-c', choices=['python', 'rlang', 'julia'], default='python', help='Code language')
     parser.add_argument('--folds', '-f', type=int, help='Override number of folds')
     parser.add_argument('--rebuild', '-r', action='store_true', 
                        help='Rebuild Docker container before running')

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-slim
 
+# -------------------------------------------------------------------
+# WARNING: This dockerfile is used only for manual grading.
+#          See environments/runtime/Dockerfile for a proper runtime.
+# -------------------------------------------------------------------
+
 WORKDIR /home/bench
 RUN apt-get update && apt-get install -y \
     ffmpeg \
@@ -8,6 +13,26 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git && \
     rm -rf /var/lib/apt/lists/*
+
+# -------------------------------------------------------------------
+# Install R (same as in full runtime, except for postintsall)
+# WARNING: packages installed by the agent are not handled!
+# -------------------------------------------------------------------
+
+RUN apt-get install -y --no-install-recommends \
+    libopenblas0-pthread \
+    littler \
+    r-cran-littler \
+    r-base \
+    r-base-dev \
+    r-base-core \
+    r-recommended \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
+    && rm -rf /var/lib/apt/lists/*
+
+# -------------------------------------------------------------------
+# Configure python
+# -------------------------------------------------------------------
 
 RUN useradd -m -U -s /bin/bash bench
 
@@ -33,4 +58,12 @@ ENV PYTHONPATH="/home/bench"
 #RUN touch submission/__init__.py # should be readonly
 RUN mkdir -p submission && chown -R bench:bench submission
 USER bench
+
+# -------------------------------------------------------------------
+# R postinstall
+# -------------------------------------------------------------------
+
+# Since we're executing the grader from the unpriviledged user, we have to make the R library folder
+RUN R -e 'dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE)'
+
 CMD [ "python", "python/bench.py" ]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -31,6 +31,70 @@ RUN apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # -------------------------------------------------------------------
+# install Julia
+# -------------------------------------------------------------------
+
+# https://github.com/docker-library/julia/blob/master/stable/bookworm/Dockerfile
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+ENV JULIA_VERSION 1.12.6
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.12.6.sha256
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') \
+			url='https://julialang-s3.julialang.org/bin/linux/x64/1.12/julia-1.12.6-linux-x86_64.tar.gz'; \
+			sha256='bbabf3bef19421a9dbd24a767d807606ab85e444323b5a1c73ffe293fa3d079a'; \
+			;; \
+		'i386') \
+			url='https://julialang-s3.julialang.org/bin/linux/x86/1.12/julia-1.12.6-linux-i686.tar.gz'; \
+			sha256='2ab43d56adfe96c7b0b9ddab0e049f54f49df24049ec8b482c26737c42af28cd'; \
+			;; \
+		'arm64') \
+			url='https://julialang-s3.julialang.org/bin/linux/aarch64/1.12/julia-1.12.6-linux-aarch64.tar.gz'; \
+			sha256='029b93b857bd0ffd627f9a8580d3bbaa63daf008d7b7aed02fbceb8fd57c4899'; \
+			;; \
+		*) \
+			echo >&2 "error: current architecture ($arch) does not have a corresponding Julia binary release"; \
+			exit 1; \
+			;; \
+	esac; \
+	\
+	curl -fL -o julia.tar.gz.asc "$url.asc"; \
+	curl -fL -o julia.tar.gz "$url"; \
+	\
+	echo "$sha256 *julia.tar.gz" | sha256sum --strict --check -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+# Disable autoremove for now
+#   apt-mark auto '.*' > /dev/null; \
+#   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+#   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+# -------------------------------------------------------------------
 # Configure python
 # -------------------------------------------------------------------
 

--- a/python/bench.py
+++ b/python/bench.py
@@ -142,8 +142,10 @@ def main():
         else:
             train_code = load_r_submission_modular()
     else: # Julia
-        common.report_error("Julia code grading is not implemented")
-        common.graceful_exit(1)
+        if params["bench_mode"] == BenchMode.MonolithicPredict:
+            train_code = load_julia_submission_mono()
+        else:
+            train_code = load_julia_submission_modular()
 
     results = grade_llm_code(train_code, params["comp_id"], params["bench_lang"], params["bench_mode"] == BenchMode.MonolithicPredict, params.get("bench_folds"), params.get("extended_schema"), params["code_lang"])
 

--- a/python/bench.py
+++ b/python/bench.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 
 import python.common as common
 from python.code_grader import grade_llm_code
+from python.foreignlang import *
 import python.ast_parser as ast_parser
 import traceback
 
@@ -18,8 +19,6 @@ class BenchMode(StrEnum):
 
 
 
-# Getting the benchmark name
-# ==========================
 def get_bench_params() -> dict:
     comp_id = os.environ.get("COMPETITION_ID")
     if not comp_id:
@@ -63,9 +62,18 @@ def get_bench_params() -> dict:
         common.report_error("Bad EXTENDED_SCHEMA value: must be one either 1/0 OR y/n OR yes/no OR true/false")
         common.graceful_exit(1)
 
+    code_lang_val = os.environ.get("CODE_LANG")
+    if not code_lang_val:
+        code_lang_val = str(common.CodeLanguage.Python)
+    try:
+        code_lang = common.CodeLanguage(code_lang_val)
+    except ValueError:
+        common.report_error(f"Bad CODE_LANG value: {code_lang_val} must be one of {[x.value for x in common.CodeLanguage]}")
+        common.graceful_exit(1)
+
     submission_name = os.environ.get("SUBMISSION_NAME")
 
-    return {"comp_id": comp_id, "bench_lang": bench_lang, "bench_mode": mode, "bench_folds": bench_folds, "extended_schema": extended_schema, "submission_name": submission_name}
+    return {"comp_id": comp_id, "bench_lang": bench_lang, "bench_mode": mode, "bench_folds": bench_folds, "extended_schema": extended_schema, "submission_name": submission_name, "code_lang": code_lang}
 
 
 # Loading the submission code
@@ -123,13 +131,21 @@ def main():
     # Init complete
 
     params = get_bench_params()
-    # params["submission_name"] = submission_name
-    if params["bench_mode"] == BenchMode.MonolithicPredict:
-        train_code = load_mono_submission()
-    else:
-        train_code = load_modular_submission()
+    if params["code_lang"] == common.CodeLanguage.Python:
+        if params["bench_mode"] == BenchMode.MonolithicPredict:
+            train_code = load_mono_submission()
+        else:
+            train_code = load_modular_submission()
+    elif params["code_lang"] == common.CodeLanguage.R:
+        if params["bench_mode"] == BenchMode.MonolithicPredict:
+            train_code = load_r_submission_mono()
+        else:
+            train_code = load_r_submission_modular()
+    else: # Julia
+        common.report_error("Julia code grading is not implemented")
+        common.graceful_exit(1)
 
-    results = grade_llm_code(train_code, params["comp_id"], params["bench_lang"], params["bench_mode"] == BenchMode.MonolithicPredict, params.get("bench_folds"), params.get("extended_schema"))
+    results = grade_llm_code(train_code, params["comp_id"], params["bench_lang"], params["bench_mode"] == BenchMode.MonolithicPredict, params.get("bench_folds"), params.get("extended_schema"), params["code_lang"])
 
     common.log_results_and_exit(results)
 

--- a/python/code_grader.py
+++ b/python/code_grader.py
@@ -12,14 +12,15 @@ from python.competition import *
 from python.foreignlang import *
 
 
-def evaluate(func: Callable, foreign_args: list, py_args: list, code_lang: common.CodeLanguage) -> Any:
-    """Convert arguments and execute Python/R/Julia code f(*foreign_args, *py_args). Only py_args are converted to the foreign language"""
+def evaluate(func: Callable, foreign_args: list, py_args: list, code_lang: common.CodeLanguage, junk: list[Any]) -> Any:
+    """Convert arguments and execute Python/R/Julia code f(*foreign_args, *py_args). Only py_args are converted to the foreign language. Junk must be deallocated in the end"""
     if code_lang == common.CodeLanguage.Python:
         return func(*foreign_args, *py_args)
     elif code_lang == common.CodeLanguage.R:
         return func(*foreign_args, *[pandas_to_r(arg) for arg in py_args])
     else: # Julia
-        pass
+        junk.append([pandas_to_julia(arg) for arg in py_args])  # make junk the owner
+        return func(*foreign_args, *junk[-1])
 
 def to_pd(output: Any, code_lang: common.CodeLanguage) -> pd.DataFrame:
     """Convert submission output to pd.DataFrame"""
@@ -28,7 +29,12 @@ def to_pd(output: Any, code_lang: common.CodeLanguage) -> pd.DataFrame:
     elif code_lang == common.CodeLanguage.R:
         return r_to_pandas(output)
     else: # Julia
-        pass
+        return julia_to_pandas(output)
+
+def cleanup_data(code_lang: common.CodeLanguage) -> None:
+    """Deallocate data in the end"""
+    if code_lang == common.CodeLanguage.Julia:
+        julia_dealloc_data()
 
 
 def grade_llm_code(train_code: dict, competition_id: str, language: str, mono_predict: bool, folds: int | None, extended_schema: bool, code_lang: common.CodeLanguage) -> dict:
@@ -124,32 +130,36 @@ def grade_llm_code(train_code: dict, competition_id: str, language: str, mono_pr
 
             # Execute the appropriate prediction function
             try:
+                junk: list[Any] = []
                 if mono_predict:
                     if extended_schema and isinstance(train_dataset, dict):
-                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [*train_dataset.values(), *val_features_dataset.values()], code_lang), code_lang)
+                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [*train_dataset.values(), *val_features_dataset.values()], code_lang, junk), code_lang)
                     else:
-                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [train_dataset, val_features_dataset], code_lang), code_lang)
+                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [train_dataset, val_features_dataset], code_lang, junk), code_lang)
                 else:
                     # Train phase
                     if extended_schema and isinstance(train_dataset, dict):
-                        train_output = evaluate(train_code["train"], [], [*train_dataset.values()], code_lang)
+                        train_output = evaluate(train_code["train"], [], [*train_dataset.values()], code_lang, junk)
                     else:
-                        train_output = evaluate(train_code["train"], [], [train_dataset], code_lang)
+                        train_output = evaluate(train_code["train"], [], [train_dataset], code_lang, junk)
 
                     # Prepare validation phase
                     if extended_schema and isinstance(val_features_dataset, dict):
-                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [*val_features_dataset.values()], code_lang)
+                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [*val_features_dataset.values()], code_lang, junk)
                     else:
-                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [val_features_dataset], code_lang)
+                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [val_features_dataset], code_lang, junk)
 
                     # Predict phase
-                    predictions = to_pd(evaluate(train_code["predict"], [train_output, val_prepared], [], code_lang), code_lang)
+                    predictions = to_pd(evaluate(train_code["predict"], [train_output, val_prepared], [], code_lang, junk), code_lang)
 
                 # Grade the predictions against true labels
                 # common.report_error(f"Grader shapes : pred {predictions.shape}; val_prepared {val_prepared.shape}; val_labels {val_labels.shape}")
                 score = GRADERS[grader](predictions, val_labels, comp.metadata, grader_data)
                 scores.append(score)
                 print(f"grade_llm_code() : finished fold {fold_idx+1}/{folds}")
+
+                del junk
+                cleanup_data(code_lang)
 
             except Exception:
                 common.report_error(f"Error during fold {fold_idx} execution: {traceback.format_exc()}")

--- a/python/code_grader.py
+++ b/python/code_grader.py
@@ -2,16 +2,36 @@ import numpy as np
 import json
 import os
 import traceback
+from typing import Callable, Any
 
 # Import from our architecture
 from loaders import DATA_LOADERS
 from python.grade_functions import GRADERS
 import python.common as common
 from python.competition import *
+from python.foreignlang import *
 
 
+def evaluate(func: Callable, foreign_args: list, py_args: list, code_lang: common.CodeLanguage) -> Any:
+    """Convert arguments and execute Python/R/Julia code f(*foreign_args, *py_args). Only py_args are converted to the foreign language"""
+    if code_lang == common.CodeLanguage.Python:
+        return func(*foreign_args, *py_args)
+    elif code_lang == common.CodeLanguage.R:
+        return func(*foreign_args, *[pandas_to_r(arg) for arg in py_args])
+    else: # Julia
+        pass
 
-def grade_llm_code(train_code: dict, competition_id: str, language: str, mono_predict: bool, folds: int | None, extended_schema: bool) -> dict:
+def to_pd(output: Any, code_lang: common.CodeLanguage) -> pd.DataFrame:
+    """Convert submission output to pd.DataFrame"""
+    if code_lang == common.CodeLanguage.Python:
+        return output
+    elif code_lang == common.CodeLanguage.R:
+        return r_to_pandas(output)
+    else: # Julia
+        pass
+
+
+def grade_llm_code(train_code: dict, competition_id: str, language: str, mono_predict: bool, folds: int | None, extended_schema: bool, code_lang: common.CodeLanguage) -> dict:
     """
     Executes LLM-generated code, computes CV scores, and returns metrics.
     """
@@ -106,19 +126,24 @@ def grade_llm_code(train_code: dict, competition_id: str, language: str, mono_pr
             try:
                 if mono_predict:
                     if extended_schema and isinstance(train_dataset, dict):
-                        predictions = train_code["train_and_predict"](*train_dataset.values(), *val_features_dataset.values())
+                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [*train_dataset.values(), *val_features_dataset.values()], code_lang), code_lang)
                     else:
-                        predictions = train_code["train_and_predict"](train_dataset, val_features_dataset)
+                        predictions = to_pd(evaluate(train_code["train_and_predict"], [], [train_dataset, val_features_dataset], code_lang), code_lang)
                 else:
                     # Train phase
-                    train_output = (train_code["train"](*train_dataset.values()) if extended_schema and isinstance(train_dataset, dict) else train_code["train"](train_dataset))
+                    if extended_schema and isinstance(train_dataset, dict):
+                        train_output = evaluate(train_code["train"], [], [*train_dataset.values()], code_lang)
+                    else:
+                        train_output = evaluate(train_code["train"], [], [train_dataset], code_lang)
 
                     # Prepare validation phase
-                    val_prepared = (train_code["prepare_val"](train_output, *val_features_dataset.values()) if extended_schema and isinstance(val_features_dataset, dict) else
-                                    train_code["prepare_val"](train_output, val_features_dataset))
+                    if extended_schema and isinstance(val_features_dataset, dict):
+                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [*val_features_dataset.values()], code_lang)
+                    else:
+                        val_prepared = evaluate(train_code["prepare_val"], [train_output], [val_features_dataset], code_lang)
 
                     # Predict phase
-                    predictions = train_code["predict"](train_output, val_prepared)
+                    predictions = to_pd(evaluate(train_code["predict"], [train_output, val_prepared], [], code_lang), code_lang)
 
                 # Grade the predictions against true labels
                 # common.report_error(f"Grader shapes : pred {predictions.shape}; val_prepared {val_prepared.shape}; val_labels {val_labels.shape}")

--- a/python/common.py
+++ b/python/common.py
@@ -5,6 +5,15 @@ import os
 import sys
 import json
 import traceback
+from enum import StrEnum
+
+
+
+class CodeLanguage(StrEnum):
+    """Supported programming languages for code generation. Same as in src.bench"""
+    Python = "python"
+    R = "rlang"
+    Julia = "julia"
 
 
 class Results:

--- a/python/foreignlang.py
+++ b/python/foreignlang.py
@@ -1,0 +1,83 @@
+import python.common as common
+
+import os
+import pandas as pd
+import numpy as np
+from importlib.metadata import version
+from packaging.version import Version as SemVer
+
+import rpy2.robjects as ro
+from rpy2.robjects.packages import importr
+from rpy2.robjects import pandas2ri, numpy2ri, default_converter
+from rpy2.rinterface import SexpVector
+if SemVer(version("rpy2")) < SemVer("2.6.1"):
+    # legacy name
+    from rpy2.robjects.packages import SignatureTranslatedAnonymousPackage as STAP
+else:
+    from rpy2.robjects.packages import STAP
+
+
+
+# =====================
+# Foreignlang (R/Julia) module, handles code loading and data conversion
+# TODO implement Python code execution prevention
+# =====================
+
+
+# Data conversion
+# ===============
+
+def pandas_to_r(df: pd.DataFrame) -> ro.vectors.DataFrame:
+    with (default_converter + pandas2ri.converter + numpy2ri.converter).context():
+        r_df = ro.conversion.get_conversion().py2rpy(df)
+    return r_df
+
+def r_to_numpy(r_vec: SexpVector) -> np.ndarray:
+    return np.asarray(r_vec)
+
+def r_to_pandas(r_df: ro.vectors.DataFrame) -> pd.DataFrame:
+    with (default_converter + pandas2ri.converter + numpy2ri.converter).context():
+        df = ro.conversion.get_conversion().rpy2py(r_df)
+    return df
+
+
+# Code execution
+# ==============
+
+def _load_r_submission() -> str:
+    code_path = "submission/code.r"
+    if not os.path.exists(code_path):
+        raise FileNotFoundError(f"File not found: {code_path}")
+
+    with open(code_path, 'r', encoding='utf-8') as f:
+        code = f.read()
+    return code
+
+def load_r_submission_mono() -> STAP:
+    code = _load_r_submission()
+    try:
+        submission = STAP(code, "submission")
+    except BaseException as e:
+        common.report_error(f"Could not load submission code: {e=}")
+        common.graceful_exit(1)
+
+    if "train_and_predict" not in submission:
+        common.report_error("Submission code does not have the train_and_predict function")
+        common.graceful_exit(1)
+
+    return submission  # should be OK to be called as a dict
+
+def load_r_submission_modular() -> STAP:
+    code = _load_r_submission()
+    try:
+        submission = STAP(code, "submission")
+    except BaseException as e:
+        common.report_error(f"Could not load submission code: {e=}")
+        common.graceful_exit(1)
+
+    for func in ["train", "prepare_val", "predict"]:
+        if func not in submission:
+            common.report_error(f"Submission code does not have the {func} function")
+            common.graceful_exit(1)
+
+    return submission  # should be OK to be called as a dict

--- a/python/foreignlang.py
+++ b/python/foreignlang.py
@@ -1,8 +1,10 @@
 import python.common as common
 
 import os
+import gc
 import pandas as pd
 import numpy as np
+import pyarrow as pa
 from importlib.metadata import version
 from packaging.version import Version as SemVer
 
@@ -16,10 +18,16 @@ if SemVer(version("rpy2")) < SemVer("2.6.1"):
 else:
     from rpy2.robjects.packages import STAP
 
+from juliacall import Main as jl
+from juliacall import Pkg as jlPkg
+from juliacall import AnyValue, VectorValue
+from juliacall import convert as jl_convert
+
 
 
 # =====================
 # Foreignlang (R/Julia) module, handles code loading and data conversion
+# Should always be imported as "from python.foreignlang import *"
 # TODO implement Python code execution prevention
 # =====================
 
@@ -40,6 +48,47 @@ def r_to_pandas(r_df: ro.vectors.DataFrame) -> pd.DataFrame:
         df = ro.conversion.get_conversion().rpy2py(r_df)
     return df
 
+# ---
+
+def pandas_to_julia(df: pd.DataFrame) -> AnyValue:
+    # Basic translation (erron-prone):
+    # return jl.DataFrame(**{col: df[col].to_numpy() for col in df.columns})
+
+    # pd -> pyarrow -> arrow.jl -> DataFrame.jl bridge (high memory usage):
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    # deallocate pyarrow table
+    del table
+    arrow_bytes = sink.getvalue().to_pybytes()
+    del sink
+    jl_bytes = jl_convert(jl.Vector[jl.UInt8], arrow_bytes)
+    del arrow_bytes
+    arrow_table = jl.Arrow.Table(jl.IOBuffer(jl_bytes))
+    # TODO check that this conversion is correct for NaN, datetime, etc
+    jl_df = jl.DataFrame(arrow_table)
+    del arrow_table
+    del jl_bytes
+    return jl_df  # probably need to call gc.collect()
+
+# def julia_to_numpy(jl_vec: VectorValue) -> np.ndarray:
+#     return np.asarray(jl_vec)
+
+def julia_to_pandas(jl_df: AnyValue) -> pd.DataFrame:
+    # Basic translation (erron-prone):
+    # col_names = [str(n) for n in jl.names(jl_df)]
+    # return pd.DataFrame({col: np.asarray(getattr(jl_df, col)) for col in col_names})
+
+    # DataFrame.jl -> arrow.jl -> pyarrow -> pd bridge (high memory usage):
+    arrow_bytes = bytes(jl._df_to_arrow_bytes(jl_df))
+    buf = pa.py_buffer(arrow_bytes)
+    return pa.ipc.open_stream(buf).read_pandas()
+
+def julia_dealloc_data() -> None:
+    """Deallocate the input dataframe. Dataframes must be explicitly deallocated using del ..."""
+    gc.collect()
+    jl.seval("GC.gc(false)")
 
 # Code execution
 # ==============
@@ -81,3 +130,52 @@ def load_r_submission_modular() -> STAP:
             common.graceful_exit(1)
 
     return submission  # should be OK to be called as a dict
+
+# ---
+
+def _load_julia_submission() -> None:
+    if not os.path.exists("submission/code.jl"):
+        raise FileNotFoundError(f"No Julia submission module code at submission/code.jl")
+    if not os.path.exists("submission/Project.toml"):
+        raise FileNotFoundError(f"No Julia submission module config at submission/Project.toml")
+
+    # We need to use the global jl namespace in order to overload pythoncall
+    try:
+        jlPkg.activate("submission")
+
+        # Julia packages config begin
+        jl.seval("using DataFrames")
+        jl.seval("using Arrow")
+        jl.seval("""
+function _df_to_arrow_bytes(df::DataFrame)::Vector{UInt8}
+    buf = IOBuffer()
+    Arrow.write(buf, df)
+    take!(buf)
+end
+""")
+        # Julia packages config end
+
+        jl.seval("using submission")
+    except BaseException as e:
+        common.report_error(f"Could not load submission code: {e=}")
+        common.graceful_exit(1)
+
+def load_julia_submission_mono() -> dict:
+    _load_julia_submission()  # loaded in the global namespace
+
+    if not hasattr(jl, "train_and_predict"):
+        common.report_error("Submission code does not have the train_and_predict function")
+        common.graceful_exit(1)
+
+    return {"train_and_predict": jl.train_and_predict}
+
+def load_julia_submission_modular() -> dict:
+    _load_julia_submission()  # loaded in the global namespace
+
+    funcs = {}
+    for func in ["train", "prepare_val", "predict"]:
+        if not hasattr(jl, func):
+            common.report_error(f"Submission code does not have the {func} function")
+            common.graceful_exit(1)
+        funcs[func] = getattr(jl, func)
+    return funcs

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -76,3 +76,5 @@ tqdm==4.67.1
 xlrd==2.0.2
 fastapi==0.116.1
 chardet
+rpy2==3.6.7
+juliacall==0.9.35

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------
+# WARNING: This file is used only for manual grading.
+#          See environments/runtime/requirements.txt.
+# -------------------------------------------------------------------
+
 #DL LIBRARIES
 keras==3.11.3
 torch==2.8.0 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -78,3 +78,4 @@ fastapi==0.116.1
 chardet
 rpy2==3.6.7
 juliacall==0.9.35
+packaging==26.2

--- a/src/bench.py
+++ b/src/bench.py
@@ -19,12 +19,12 @@ from python.splitters import *
 class CodeLanguage(StrEnum):
     """Supported programming languages for code generation"""
     Python = "python"
-    #R = "rlang"
-    #Julia = "julia"
+    R = "rlang"
+    Julia = "julia"
 
 
-CODEPATHS = {CodeLanguage.Python: "code.py",} #CodeLanguage.R: None, CodeLanguage.Julia: None}
-CODE_EXT = {CodeLanguage.Python: ".py"}
+CODEPATHS = {CodeLanguage.Python: "code.py", CodeLanguage.R: "code.r", CodeLanguage.Julia: "code.jl"}
+CODE_EXT = {CodeLanguage.Python: ".py", CodeLanguage.R: ".r", CodeLanguage.Julia: ".jl"}
 
 
 class RunnerInput(StrEnum):
@@ -224,6 +224,7 @@ class BenchPipeline:
             "BENCH_LANG": str(lang),
             "BENCH_MODE": str(BenchMode.ModularPredict),
             "EXTENDED_SCHEMA": str(int(extended_schema)),
+            "CODE_LANG": str(codelang),
             "BENCH_FOLDS_OVERRIDE": "1",
             "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONPATH": "/home/bench"

--- a/src/bench.py
+++ b/src/bench.py
@@ -214,6 +214,13 @@ class BenchPipeline:
         if codelang == CodeLanguage.Python:
             with open(os.path.join(submission_dir, "__init__.py"), 'w') as f:
                 f.write("")
+        elif codelang == CodeLanguage.Julia:
+            with open(os.path.join(submission_dir, "Project.toml", 'w')) as f:
+                f.write("""
+name = \"submission\"
+uuid = \"202b1717-a144-4415-8d3a-a1bfc0cbf60e\"
+version = \"0.0.1\"
+""")  # TODO check that this Project.toml is ok
 
         with open(os.path.join(submission_dir, CODEPATHS[codelang]), 'w') as f:
             f.write(code)


### PR DESCRIPTION
This PR adds R and Julia support to the grader.

- [X] Add R install to [environments/runtime/Dockerfile](environments/runtime/Dockerfile) and [python/Dockerfile](python/Dockerfile)
- [x] Add Julia install to the same dockerfiles
- [ ] Add essential R packages (especially to the manual grader)
- [ ] Add essential Julia packages (especially to the manual grader)
- [X] Add R code support to the code grader
- [X] Add Julia code support to the code grader
- [ ] Modify net policies to allow R/Julia packages

Next steps:
- [ ] Add grader-side python isolation (R)
- [ ] Add grader-side python isolation (Julia)
- [ ] Make sure that data conversion is correct (especially for competitions with advanced pandas features)

Agents TODO:
- [ ] Modify ReAct to work with R/Julia
- [ ] Add agent-side python binaries isolation and stricter net policies

Limitations:
- Manual grader dockerfile doesn't handle packages installed by the agent
- No R cuda support